### PR TITLE
Skip push if only application components have changed

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -57,3 +57,5 @@ jq -r '.resources[] | select(.resourceType == "APPLICATION") | .location' "$CONF
     printf "\nChecking %s for changes...\n" "$location"
     push_resource "$location"
 done
+
+printf "\nChecking complete. Exiting...\n"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -43,7 +43,7 @@ fi
 push_resource() {
     local location="$1"
     # Skip push if only components have changed
-    if echo "$changed_files" | grep -P "^${location}/(?!components/)"; then
+    if echo "$changed_files" | grep -qP "^${location}/(?!components/)"; then
         printf "\nChange detected. Pushing...\n"
         superblocks push "$location"
     else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -42,8 +42,9 @@ fi
 # Function to push a resource to Superblocks if it has changed
 push_resource() {
     local location="$1"
-    # Skip push if only components have changed
-    if echo "$changed_files" | grep -qP "^${location}/(?!components/)"; then
+    # Push only if there are some changes to $location/application.yaml, $location/page.yaml, or $location/apis/*.
+    # This is to avoid pushing when only the components have changed.
+    if echo "$changed_files" | grep -qP "^${location}/(application|page).yaml" || echo "$changed_files" | grep -qP "^${location}/apis/" ; then
         printf "\nChange detected. Pushing...\n"
         superblocks push "$location"
     else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -42,9 +42,12 @@ fi
 # Function to push a resource to Superblocks if it has changed
 push_resource() {
     local location="$1"
-    if echo "$changed_files" | grep -q "^$location/"; then
+    # Skip push if only components have changed
+    if echo "$changed_files" | grep -P "^${location}/(?!components/)"; then
         printf "\nChange detected. Pushing...\n"
         superblocks push "$location"
+    else
+        printf "\nNo change detected. Skipping push...\n"
     fi
 }
 


### PR DESCRIPTION
This PR makes it so that we grep for specific changes in an app when deciding whether or not to push an application to Superblocks. This is to avoid pushing to an application when the only changes are custom components related.

The list of file locations we care about currently are:
- apps/${app_name}/application.yaml
- apps/${app_name}/page.yaml
- apps/${app_name}/apis/
