### PR TITLE
Make entrypoint script git-vendor agnostic

### DIFF
--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -1,0 +1,69 @@
+name: Publish docker images
+
+on:
+  push:
+    branches:
+      - '**'
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - 'main'
+
+env:
+  DOCKERHUB_IMAGE_NAME: superblocksteam/import-action
+  GHCR_IMAGE_NAME: ghcr.io/superblocksteam/import-action
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            ${{ env.DOCKERHUB_IMAGE_NAME }}
+            ${{ env.GHCR_IMAGE_NAME }}
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            # branch event
+            type=ref,event=branch
+            # tag event
+            type=ref,event=tag
+            # pull request event
+            type=ref,event=pr
+            type=sha
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        if: github.event_name == 'push' && github.ref_type == 'tag'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GHCR
+        if: github.event_name == 'push' && github.ref_type == 'tag'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/update-readme.yaml
+++ b/.github/workflows/update-readme.yaml
@@ -1,4 +1,4 @@
-name: Update README.md with the latest actions.yml
+name: Auto-update README.md based on action.yaml
 
 on:
   push:
@@ -11,28 +11,27 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Run auto-doc
         uses: tj-actions/auto-doc@v3
         with:
           filename: 'action.yaml'
           markdown_links: 'false'
+          col_max_words: '20'
 
-      - name: Verify Changed files
+      - name: Verify changed files
         uses: tj-actions/verify-changed-files@v16
         id: verify-changed-files
         with:
           files: |
             README.md
 
-      - name: Create Pull Request
+      - name: Create pull request
         if: steps.verify-changed-files.outputs.files_changed == 'true'
         uses: peter-evans/create-pull-request@v5
         with:
           base: 'main'
-          title: 'auto-doc: Updated README.md'
+          title: 'auto-doc: updated README.md'
           branch: 'chore/auto-doc-update-readme'
-          commit-message: 'auto-doc: Updated README.md'
-          body: 'auto-doc: Updated README.md'
+          commit-message: 'auto-doc: updated README.md'
+          body: 'auto-doc: updated README.md'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,15 @@
 FROM node:18-bookworm-slim
 
-COPY entrypoint.sh /entrypoint.sh
+ARG SUPERBLOCKS_CLI_VERSION='^1.1.0'
 
 # Install Superblocks CLI dependencies
 RUN apt-get update && apt-get install -y \
   git \
   jq \
   && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g @superblocksteam/cli@"${SUPERBLOCKS_CLI_VERSION}"
+
+COPY entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -58,13 +58,12 @@ If your organization uses Superblocks EU, set the `domain` to `eu.superblocks.co
 
 <!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
 
-|    INPUT    |  TYPE  | REQUIRED |              DEFAULT              |                        DESCRIPTION                        |
-|-------------|--------|----------|-----------------------------------|-----------------------------------------------------------|
-| cli_version | string |  false   |            `"^1.1.0"`             |                The Superblocks CLI version                |
-|   domain    | string |  false   |      `"app.superblocks.com"`      | The Superblocks domain where applications <br>are hosted  |
-|    path     | string |  false   | `".superblocks/superblocks.json"` |   The relative path to the <br>Superblocks config file    |
-|     sha     | string |  false   |             `"HEAD"`              |                Commit to push changes for                 |
-|    token    | string |   true   |                                   |         The Superblocks access token to <br>use           |
+| INPUT  |  TYPE  | REQUIRED |              DEFAULT              |                     DESCRIPTION                      |
+|--------|--------|----------|-----------------------------------|------------------------------------------------------|
+| domain | string |  false   |      `"app.superblocks.com"`      | The Superblocks domain where applications are hosted |
+|  path  | string |  false   | `".superblocks/superblocks.json"` |   The relative path to the Superblocks config file   |
+|  sha   | string |  false   |             `"HEAD"`              |              Commit to push changes for              |
+| token  | string |   true   |                                   |         The Superblocks access token to use          |
 
 <!-- AUTO-DOC-INPUT:END -->
 

--- a/action.yaml
+++ b/action.yaml
@@ -13,9 +13,6 @@ inputs:
   path:
     description: 'The relative path to the Superblocks config file'
     default: '.superblocks/superblocks.json'
-  cli_version:
-    description: 'The Superblocks CLI version'
-    default: '^1.1.0'
 
 runs:
   using: 'docker'
@@ -25,4 +22,6 @@ runs:
     - ${{ inputs.token }}
     - ${{ inputs.domain }}
     - ${{ inputs.path }}
-    - ${{ inputs.cli_version }}
+  env:
+    SUPERBLOCKS_AUTHOR_NAME: 'superblocks-app[bot]'
+    SUPERBLOCKS_COMMIT_MESSAGE_IDENTIFIER: '[superblocks ci]'

--- a/action.yaml
+++ b/action.yaml
@@ -16,7 +16,7 @@ inputs:
 
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  image: 'superblocksteam/import-action:v1.0.2'
   args:
     - ${{ inputs.sha }}
     - ${{ inputs.token }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,11 +8,16 @@ TOKEN="$2"
 DOMAIN="$3"
 CONFIG_PATH="$4"
 CLI_VERSION="$5"
+REPO_DIR=${REPO_DIR:-$GITHUB_WORKSPACE}
 
 SUPERBLOCKS_BOT_NAME="superblocks-app[bot]"
 
-cd "$GITHUB_WORKSPACE"
-git config --global --add safe.directory "$GITHUB_WORKSPACE"
+echo "WORKSPACE: $GITHUB_WORKSPACE"
+echo "CURRENT DIR: $(pwd)"
+echo "REPO_DIR: $REPO_DIR"
+
+cd "$REPO_DIR"
+git config --global --add safe.directory "$REPO_DIR"
 
 # Get the name of the actor who made the last commit
 actor_name=$(git show -s --format='%an' "$SHA")

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,21 +7,25 @@ SHA="$1"
 TOKEN="$2"
 DOMAIN="$3"
 CONFIG_PATH="$4"
-CLI_VERSION="$5"
-REPO_DIR=${REPO_DIR:-$GITHUB_WORKSPACE}
 
-SUPERBLOCKS_BOT_NAME="superblocks-app[bot]"
+SUPERBLOCKS_AUTHOR_NAME="${SUPERBLOCKS_AUTHOR_NAME:-superblocks-app[bot]}"
+SUPERBLOCKS_COMMIT_MESSAGE_IDENTIFIER="${SUPERBLOCKS_COMMIT_MESSAGE_IDENTIFIER:-[superblocks ci]}"
 
-echo "WORKSPACE: $GITHUB_WORKSPACE"
-echo "CURRENT DIR: $(pwd)"
-echo "REPO_DIR: $REPO_DIR"
+if [ -z "$REPO_DIR" ]; then
+  REPO_DIR="$(pwd)"
+else
+  cd "$REPO_DIR"
+fi
 
-cd "$REPO_DIR"
 git config --global --add safe.directory "$REPO_DIR"
 
-# Get the name of the actor who made the last commit
+# Get the actor name and commit message the last commit
 actor_name=$(git show -s --format='%an' "$SHA")
-if [ "$actor_name" == "$SUPERBLOCKS_BOT_NAME" ]; then
+commit_message=$(git show -s --format='%B' "$SHA")
+
+# Skip push if the commit was made by Superblocks. To support multiple Git providers, we also
+# check for specific identifier text in the commit message.
+if [ "$actor_name" == "$SUPERBLOCKS_AUTHOR_NAME" ] || echo "$commit_message" | grep -qF "$SUPERBLOCKS_COMMIT_MESSAGE_IDENTIFIER" ; then
     printf "\nCommit was made by Superblocks. Skipping push...\n"
     exit 0
 fi
@@ -30,9 +34,6 @@ fi
 changed_files=$(git diff "${SHA}"^ --name-only)
 
 if [ -n "$changed_files" ]; then
-    # Install Superblocks CLI
-    printf "\nInstalling Superblocks CLI (%s)...\n" "$CLI_VERSION"
-    npm install -g @superblocksteam/cli@"$CLI_VERSION"
     superblocks --version
 
     # Login to Superblocks


### PR DESCRIPTION
This PR:
- Removes vendor-specific logic for commit checking and git directory config
- Removes CLI installation from the entrypoint, and moves it to the image
- Updates action.yaml to reference the built image and not the Dockerfile
- Adds a workflow to publish images on version tag creation