### PR TITLE
Replace fixed image name with Dockerfile ref

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -16,7 +16,7 @@ inputs:
 
 runs:
   using: 'docker'
-  image: 'superblocksteam/import-action:v1.0.2'
+  image: 'Dockerfile'
   args:
     - ${{ inputs.sha }}
     - ${{ inputs.token }}


### PR DESCRIPTION
This simplifies the use of the correct image, otherwise we would need to first update the image contents in one PR, and the add another PR to replace the image ref once the tag is created and image is built