### PR TITLE
Use RC build of CLI to enable workflows and jobs push support

### DIFF
--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -73,3 +73,5 @@ jobs:
           push: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            NPM_TOKEN=${{ secrets.GH_PACKAGES_READ_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:18-bookworm-slim
 
-ARG SUPERBLOCKS_CLI_VERSION='^1.1.0'
+ARG SUPERBLOCKS_CLI_VERSION='1.4.0-rc.1'
+ARG NPM_TOKEN
 
 # Install Superblocks CLI dependencies
 RUN apt-get update && apt-get install -y \
@@ -8,7 +9,12 @@ RUN apt-get update && apt-get install -y \
   jq \
   && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g @superblocksteam/cli@"${SUPERBLOCKS_CLI_VERSION}"
+RUN npm set "//npm.pkg.github.com/:_authToken" "${NPM_TOKEN}" && \
+  npm set "@superblocksteam:registry" "https://npm.pkg.github.com/" && \
+  # Install Superblocks CLI
+  npm install -g @superblocksteam/cli@"${SUPERBLOCKS_CLI_VERSION}" && \
+  # Cleanup
+  rm -rf ~/.npmrc
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ See the [Source Control documentation](https://docs.superblocks.com/development-
 
 <!-- AUTO-DOC-DESCRIPTION:START - Do not remove or modify this section -->
 
-Push applications to Superblocks
+Push Applications, Workflows, and Scheduled Jobs to Superblocks
 
 <!-- AUTO-DOC-DESCRIPTION:END -->
 
 ## Usage
 
 ```yaml
-name: Sync application changes to Superblocks
+name: Sync Applications, Workflows, and Scheduled Jobs changes to Superblocks
 on: [push]
 
 jobs:
@@ -58,12 +58,12 @@ If your organization uses Superblocks EU, set the `domain` to `eu.superblocks.co
 
 <!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
 
-| INPUT  |  TYPE  | REQUIRED |              DEFAULT              |                     DESCRIPTION                      |
-|--------|--------|----------|-----------------------------------|------------------------------------------------------|
-| domain | string |  false   |      `"app.superblocks.com"`      | The Superblocks domain where applications are hosted |
-|  path  | string |  false   | `".superblocks/superblocks.json"` |   The relative path to the Superblocks config file   |
-|  sha   | string |  false   |             `"HEAD"`              |              Commit to push changes for              |
-| token  | string |   true   |                                   |         The Superblocks access token to use          |
+| INPUT  |  TYPE  | REQUIRED |              DEFAULT              |                    DESCRIPTION                    |
+|--------|--------|----------|-----------------------------------|---------------------------------------------------|
+| domain | string |  false   |      `"app.superblocks.com"`      | The Superblocks domain where resources are hosted |
+|  path  | string |  false   | `".superblocks/superblocks.json"` | The relative path to the Superblocks config file  |
+|  sha   | string |  false   |             `"HEAD"`              |            Commit to push changes for             |
+| token  | string |   true   |                                   |        The Superblocks access token to use        |
 
 <!-- AUTO-DOC-INPUT:END -->
 

--- a/action.yaml
+++ b/action.yaml
@@ -1,11 +1,11 @@
 name: 'Superblocks Import'
-description: 'Push applications to Superblocks'
+description: 'Push Applications, Workflows, and Scheduled Jobs to Superblocks'
 inputs:
   token:
     description: 'The Superblocks access token to use'
     required: true
   domain:
-    description: 'The Superblocks domain where applications are hosted'
+    description: 'The Superblocks domain where resources are hosted'
     default: 'app.superblocks.com'
   path:
     description: 'The relative path to the Superblocks config file'

--- a/action.yaml
+++ b/action.yaml
@@ -16,7 +16,7 @@ inputs:
 
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  image: 'superblocksteam/import-action:v1'
   env:
     SUPERBLOCKS_TOKEN: ${{ inputs.token }}
     SUPERBLOCKS_DOMAIN: ${{ inputs.domain }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,7 +39,7 @@ fi
 # Function to push a resource to Superblocks if it has changed
 push_resource() {
     local location="$1"
-    # Push only if there are some changes to $location/application.yaml, $location/page.yaml, or $location/apis/*.
+    # Push only if there are some changes to $location/application.yaml, $location/page.yaml, $location/api.yaml, or $location/apis/*.
     # This is to avoid pushing when only the components have changed.
     if echo "$changed_files" | grep -qP "^${location}/(application|page|api).yaml" || echo "$changed_files" | grep -qP "^${location}/apis/" ; then
         printf "\nChange detected. Pushing...\n"


### PR DESCRIPTION
Changes to `action.yaml`, `Dockerfile` and `.github/workflows/publish-image.yaml` are temporary. These changes allow us to fetch the CLI package from the private NPM registry