### PR TITLE
Install CLI at runtime, not build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,10 @@
 FROM node:18-bookworm-slim
 
-ARG SUPERBLOCKS_CLI_VERSION='1.4.0-rc.4'
-ARG NPM_TOKEN
-
 # Install Superblocks CLI dependencies
 RUN apt-get update && apt-get install -y \
   git \
   jq \
   && rm -rf /var/lib/apt/lists/*
-
-RUN npm set "//npm.pkg.github.com/:_authToken" "${NPM_TOKEN}" && \
-  npm set "@superblocksteam:registry" "https://npm.pkg.github.com/" && \
-  # Install Superblocks CLI
-  npm install -g @superblocksteam/cli@"${SUPERBLOCKS_CLI_VERSION}" && \
-  # Cleanup
-  rm -rf ~/.npmrc
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,8 @@
 set -e
 set -o pipefail
 
+SUPERBLOCKS_CLI_VERSION="${SUPERBLOCKS_CLI_VERSION:-^1.4.0}"
+
 COMMIT_SHA="${COMMIT_SHA:-HEAD}"
 SUPERBLOCKS_DOMAIN="${SUPERBLOCKS_DOMAIN:-app.superblocks.com}"
 SUPERBLOCKS_CONFIG_PATH="${SUPERBLOCKS_CONFIG_PATH:-.superblocks/superblocks.json}"
@@ -25,6 +27,9 @@ git config --global --add safe.directory "$REPO_DIR"
 changed_files=$(git diff "${COMMIT_SHA}"^ --name-only)
 
 if [ -n "$changed_files" ]; then
+    # Install Superblocks CLI
+    npm install -g @superblocksteam/cli@"${SUPERBLOCKS_CLI_VERSION}"
+
     superblocks --version
 
     # Login to Superblocks


### PR DESCRIPTION
This ensures that the latest version of the CLI is being used.

Additionally, remove the use of a private npm registry.