### PR TITLE
Support Superblocks resources not directly at repo root

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -8,8 +8,8 @@ inputs:
     description: 'The Superblocks domain where resources are hosted'
     default: 'app.superblocks.com'
   path:
-    description: 'The relative path to the Superblocks config file'
-    default: '.superblocks/superblocks.json'
+    description: 'The relative path from repo root to the Superblocks root directory. This is where the ~.superblocks/superblocks.json config file is located.'
+    default: '.'
   sha:
     description: 'Commit to push changes for'
     default: 'HEAD'
@@ -20,5 +20,5 @@ runs:
   env:
     SUPERBLOCKS_TOKEN: ${{ inputs.token }}
     SUPERBLOCKS_DOMAIN: ${{ inputs.domain }}
-    SUPERBLOCKS_CONFIG_PATH: ${{ inputs.path }}
+    SUPERBLOCKS_PATH: ${{ inputs.path }}
     COMMIT_SHA: ${{ inputs.sha }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,7 +7,9 @@ SUPERBLOCKS_CLI_VERSION="${SUPERBLOCKS_CLI_VERSION:-^1.4.0}"
 
 COMMIT_SHA="${COMMIT_SHA:-HEAD}"
 SUPERBLOCKS_DOMAIN="${SUPERBLOCKS_DOMAIN:-app.superblocks.com}"
-SUPERBLOCKS_CONFIG_PATH="${SUPERBLOCKS_CONFIG_PATH:-.superblocks/superblocks.json}"
+SUPERBLOCKS_PATH="${SUPERBLOCKS_PATH:.}"
+
+SUPERBLOCKS_CONFIG_RELATIVE_PATH=".superblocks/superblocks.json"
 
 # Ensure that a Superblocks token is provided
 if [ -z "$SUPERBLOCKS_TOKEN" ]; then
@@ -24,7 +26,10 @@ fi
 git config --global --add safe.directory "$REPO_DIR"
 
 # Get the list of changed files in the last commit
-changed_files=$(git diff "${COMMIT_SHA}"^ --name-only)
+changed_files=$(git diff "${COMMIT_SHA}"^ --name-only -- "$SUPERBLOCKS_PATH")
+
+# Change the working directory to the Superblocks path
+pushd "$SUPERBLOCKS_PATH"
 
 if [ -n "$changed_files" ]; then
     # Install Superblocks CLI
@@ -63,7 +68,7 @@ push_resource() {
 }
 
 # Check if any push-compatible resources have changed
-jq -r '.resources[] | .location' "$SUPERBLOCKS_CONFIG_PATH" | while read -r location; do
+jq -r '.resources[] | .location' "$SUPERBLOCKS_CONFIG_RELATIVE_PATH" | while read -r location; do
     printf "\nChecking %s for changes...\n" "$location"
     push_resource "$location"
 done


### PR DESCRIPTION
This PR changes the meaning of the `path` input to be the Superblocks root path relative to repo root. 

In the entrypoint script, we remove env var support of `SUPERBLOCKS_CONFIG_PATH` and instead start taking in a `SUPERBLOCKS_PATH` env var.

With these changes, we truly support Superblocks assets living in a nested directory within a repo