### PR TITLE
Fix permissions for image publish

### DIFF
--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -10,6 +10,10 @@ on:
     branches:
       - 'main'
 
+permissions:
+  contents: read
+  packages: write
+
 env:
   DOCKERHUB_IMAGE_NAME: superblocksteam/import-action
   GHCR_IMAGE_NAME: ghcr.io/superblocksteam/import-action
@@ -73,5 +77,3 @@ jobs:
           push: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            NPM_TOKEN=${{ secrets.GH_PACKAGES_READ_TOKEN }}


### PR DESCRIPTION
Also, remove an unreferenced build arg that was used when we used to try to install RC versions of the cli