### PR TITLE
Detect changes in .py or .js files in import action

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -59,8 +59,10 @@ push_resource() {
     #   pages/*
     #   apis/*
     #   api.yaml
+    #   *.js
+    #   *.py
     # This specificity ensures that we avoid pushing when only the components subdir has changes.
-    if echo "$changed_files" | grep -qP "${escaped_location}/((application|page|api).yaml|apis/|pages/)" ; then
+    if echo "$changed_files" | grep -qP "${escaped_location}/((application|page|api).yaml|.*\.js|.*\.py|apis/|pages/)" ; then
         printf "\nChange detected. Pushing...\n"
         superblocks push "$location"
     else


### PR DESCRIPTION
We want to detect changes in `.py` or `.js` files in the resource in addition to `.yaml` files. Especially for backend resources such as **workflows** or **scheduled jobs**. 

This change allows the parsing in `entrypoint.sh` to detect changes in `.py` and `.js` files and trigger a `superblocks push` if changes exists in those two types of files.